### PR TITLE
Enable network access for sandboxed app

### DIFF
--- a/AIOverlay/AIOverlay.entitlements
+++ b/AIOverlay/AIOverlay.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow sandboxed app to make outbound network requests by adding `com.apple.security.network.client` entitlement

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c13d58ce688328a58ded68903ce306