### PR TITLE
Enable network access for sandboxed app

### DIFF
--- a/AIOverlay/AIOverlay.entitlements
+++ b/AIOverlay/AIOverlay.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
 </dict>
 </plist>

--- a/AIOverlay/ChatClient.swift
+++ b/AIOverlay/ChatClient.swift
@@ -17,7 +17,16 @@ private let netLog = Logger(subsystem: "AIOverlay", category: "network")
 
 final class ChatClient: ObservableObject {
     @Published var backend: ChatBackend = .ollama()  // default to local for easy testing
-    var systemPreamble = "You are a helpful macOS overlay assistant."
+
+    // Persist the system preamble so users can customize it in settings
+    var systemPreamble: String {
+        didSet { UserDefaults.standard.set(systemPreamble, forKey: "systemPreamble") }
+    }
+
+    init() {
+        self.systemPreamble = UserDefaults.standard.string(forKey: "systemPreamble") ??
+            "You are a helpful macOS overlay assistant."
+    }
 
     // Attach screen context to the *next* user message only
     private var pendingContext: String?

--- a/AIOverlay/SettingsView.swift
+++ b/AIOverlay/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @State private var apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? ""
     @State private var openAIModel = "gpt-4o-mini"
     @State private var ollamaModel = "llama3.1"
+    @State private var systemPreamble = ""
 
     @Environment(\.dismiss) private var dismiss   // <-- add
 
@@ -20,6 +21,8 @@ struct SettingsView: View {
             } else {
                 TextField("Ollama Model", text: $ollamaModel)
             }
+
+            TextField("System Preamble", text: $systemPreamble)
 
             Button("Apply") {
                 apply()
@@ -36,6 +39,7 @@ struct SettingsView: View {
             case .ollama(let model):
                 useOpenAI = false; ollamaModel = model
             }
+            systemPreamble = chat.systemPreamble
         }
     }
 
@@ -45,5 +49,6 @@ struct SettingsView: View {
         } else {
             chat.backend = .ollama(model: ollamaModel)
         }
+        chat.systemPreamble = systemPreamble
     }
 }


### PR DESCRIPTION
## Summary
- allow sandboxed app to make outbound network requests by adding `com.apple.security.network.client` entitlement
- expose the system preamble in Settings so users can customize the assistant prompt

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c13d58ce688328a58ded68903ce306