### PR TITLE
Enable network access and style overlay messages

### DIFF
--- a/AIOverlay/AIOverlay.entitlements
+++ b/AIOverlay/AIOverlay.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
 </dict>
 </plist>

--- a/AIOverlay/AppViewModel.swift
+++ b/AIOverlay/AppViewModel.swift
@@ -3,7 +3,9 @@ import SwiftUI
 final class AppViewModel: ObservableObject {
     let overlay = OverlayController()
     let context = ScreenContext()
-    @Published var messages: [String] = ["👋 Overlay ready."]
+    @Published var messages: [ChatMessage] = [
+        ChatMessage(sender: .assistant, text: "👋 Overlay ready.")
+    ]
     @Published var chat = ChatClient()
 
     func showOverlay() {
@@ -16,7 +18,7 @@ final class AppViewModel: ObservableObject {
             messages: self.messages,
             onSend: { [weak self] text in
                 guard let self = self else { return }
-                self.messages.append("You: \(text)")
+                self.messages.append(ChatMessage(sender: .user, text: text))
                 self.overlay.setContent(rootView: self.makeOverlayView())
 
                 self.chat.send(user: text) { result in
@@ -24,10 +26,10 @@ final class AppViewModel: ObservableObject {
                         guard let self = self else { return }
                         switch result {
                         case .success(let reply):
-                            self.messages.append("Assistant: \(reply)")
+                            self.messages.append(ChatMessage(sender: .assistant, text: reply))
                         case .failure(let err):
                             let raw = (err as NSError).userInfo["raw"] as? String
-                            self.messages.append("⚠️ Error: \(raw ?? err.localizedDescription)")
+                            self.messages.append(ChatMessage(sender: .assistant, text: "⚠️ Error: \(raw ?? err.localizedDescription)"))
                         }
                         self.overlay.setContent(rootView: self.makeOverlayView())
                     }
@@ -37,7 +39,7 @@ final class AppViewModel: ObservableObject {
                 guard let self = self else { return }
                 Task { @MainActor in
                     let grabbed = await self.context.getContextText()
-                    self.messages.append("• Captured preview:\n\(String(grabbed.prefix(300)))…")
+                    self.messages.append(ChatMessage(sender: .assistant, text: "• Captured preview:\n\(String(grabbed.prefix(300)))…"))
                     self.chat.attachContext(grabbed)
                     self.overlay.setContent(rootView: self.makeOverlayView())
                 }

--- a/AIOverlay/ChatMessage.swift
+++ b/AIOverlay/ChatMessage.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum Sender {
+    case user
+    case assistant
+}
+
+struct ChatMessage: Identifiable {
+    let id = UUID()
+    let sender: Sender
+    let text: String
+}
+

--- a/AIOverlay/OverlayView.swift
+++ b/AIOverlay/OverlayView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct OverlayView: View {
-    let messages: [String]
+    let messages: [ChatMessage]
     let onSend: (String) -> Void
     let onUseScreenContext: () -> Void
 
@@ -16,15 +16,30 @@ struct OverlayView: View {
             }
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(messages.indices, id: \.self) { i in
-                        Text(messages[i])
-                            .padding(6)
-                            .background(Color.gray.opacity(0.08))
-                            .cornerRadius(8)
+                VStack(spacing: 6) {
+                    ForEach(messages) { msg in
+                        HStack {
+                            if msg.sender == .assistant {
+                                Text(msg.text)
+                                    .padding(8)
+                                    .background(Color.gray.opacity(0.2))
+                                    .foregroundColor(.primary)
+                                    .cornerRadius(12)
+                                    .textSelection(.enabled)
+                                Spacer()
+                            } else {
+                                Spacer()
+                                Text(msg.text)
+                                    .padding(8)
+                                    .background(Color.blue)
+                                    .foregroundColor(.white)
+                                    .cornerRadius(12)
+                                    .textSelection(.enabled)
+                            }
+                        }
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity)
             }
 
             HStack {

--- a/AIOverlay/SettingsView.swift
+++ b/AIOverlay/SettingsView.swift
@@ -6,13 +6,14 @@ struct SettingsView: View {
     @State private var apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? ""
     @State private var openAIModel = "gpt-4o-mini"
     @State private var ollamaModel = "llama3.1"
+    @State private var systemPreamble = ""
 
     @Environment(\.dismiss) private var dismiss   // <-- add
 
     var body: some View {
         Form {
             Toggle("Use OpenAI (off = Ollama)", isOn: $useOpenAI)
-                .onChange(of: useOpenAI) { _ in apply() }  // keep: apply but don't dismiss
+                .onChange(of: useOpenAI) { apply() }  // keep: apply but don't dismiss
 
             if useOpenAI {
                 TextField("OpenAI API Key", text: $apiKey)
@@ -20,6 +21,8 @@ struct SettingsView: View {
             } else {
                 TextField("Ollama Model", text: $ollamaModel)
             }
+
+            TextField("System Preamble", text: $systemPreamble)
 
             Button("Apply") {
                 apply()
@@ -36,6 +39,7 @@ struct SettingsView: View {
             case .ollama(let model):
                 useOpenAI = false; ollamaModel = model
             }
+            systemPreamble = chat.systemPreamble
         }
     }
 
@@ -45,5 +49,6 @@ struct SettingsView: View {
         } else {
             chat.backend = .ollama(model: ollamaModel)
         }
+        chat.systemPreamble = systemPreamble
     }
 }


### PR DESCRIPTION
## Summary
- allow sandboxed app to make outbound network requests by adding `com.apple.security.network.client` entitlement
- expose the system preamble in Settings so users can customize the assistant prompt
- style user and assistant messages like iMessage with selectable text
- resolve `ChatMessage` redeclaration by introducing an internal `APIMessage` for LLM payloads and modernize Settings `onChange` usage
- retain chat history in `ChatClient` so each request includes prior messages

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68c13d58ce688328a58ded68903ce306