### PR TITLE
Capture and OCR screen for context

### DIFF
--- a/AIOverlay/AppViewModel.swift
+++ b/AIOverlay/AppViewModel.swift
@@ -38,10 +38,12 @@ final class AppViewModel: ObservableObject {
             onUseScreenContext: { [weak self] in
                 guard let self = self else { return }
                 Task { @MainActor in
+                    self.overlay.hide()
                     let grabbed = await self.context.getContextText()
                     self.messages.append(ChatMessage(sender: .assistant, text: "• Captured preview:\n\(String(grabbed.prefix(300)))…"))
                     self.chat.attachContext(grabbed)
                     self.overlay.setContent(rootView: self.makeOverlayView())
+                    self.overlay.show()
                 }
             }
         )

--- a/AIOverlay/OverlayController.swift
+++ b/AIOverlay/OverlayController.swift
@@ -24,4 +24,15 @@ final class OverlayController {
         }
         window?.contentView = NSHostingView(rootView: AnyView(rootView))
     }
+
+    func hide() {
+        window?.orderOut(nil)
+    }
+
+    func show() {
+        if let window = window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
 }

--- a/AIOverlay/ScreenContext.swift
+++ b/AIOverlay/ScreenContext.swift
@@ -1,8 +1,103 @@
 import Foundation
+import AppKit
+import Vision
+import ScreenCaptureKit
+import CoreImage
 
 final class ScreenContext {
-    // For now, just return a fake string so the app compiles.
+    /// Capture the main display, gather a bit of metadata about the
+    /// foreground window, run OCR on the screenshot and return everything as
+    /// a textual blob suitable for sending as chat context.
     func getContextText() async -> String {
-        return "🔖 (stub) screen context goes here"
+        guard let cgImage = await captureMainDisplay() else {
+            return "(screenshot failed)"
+        }
+
+        var meta: [String] = []
+
+        // Frontmost application name and window title if available
+        if let app = NSWorkspace.shared.frontmostApplication {
+            meta.append("Frontmost app: \(app.localizedName ?? "?")")
+
+            let pid = app.processIdentifier
+            if let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements],
+                                                        kCGNullWindowID) as? [[String: Any]] {
+                if let front = windows.first(where: { ($0[kCGWindowOwnerPID as String] as? pid_t) == pid &&
+                                                      ($0[kCGWindowLayer as String] as? Int) == 0 }) {
+                    if let title = front[kCGWindowName as String] as? String, !title.isEmpty {
+                        meta.append("Window title: \(title)")
+                    }
+                }
+            }
+        }
+
+        meta.append("Resolution: \(cgImage.width)x\(cgImage.height)")
+
+        // OCR the screenshot
+        let request = VNRecognizeTextRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        var text = ""
+        do {
+            try handler.perform([request])
+            let observations = request.results ?? []
+            text = observations.compactMap { $0.topCandidates(1).first?.string }
+                                 .joined(separator: "\n")
+        } catch {
+            text = "(OCR failed: \(error.localizedDescription))"
+        }
+
+        return (meta + ["", text]).joined(separator: "\n")
+    }
+
+    /// Capture the main display into a `CGImage` using ScreenCaptureKit.
+    private func captureMainDisplay() async -> CGImage? {
+        do {
+            let content = try await SCShareableContent.current
+            guard let display = content.displays.first else { return nil }
+
+            let filter = SCContentFilter(display: display,
+                                         excludingApplications: [],
+                                         exceptingWindows: [])
+            let config = SCStreamConfiguration()
+            config.width = display.width
+            config.height = display.height
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            let collector = FrameCollector()
+            try stream.addStreamOutput(collector, type: .screen, sampleHandlerQueue: collector.queue)
+            try await stream.startCapture()
+            defer { stream.stopCapture() }
+
+            return await collector.image
+        } catch {
+            return nil
+        }
+    }
+}
+
+private final class FrameCollector: NSObject, SCStreamOutput {
+    let queue = DispatchQueue(label: "FrameCollector")
+    private let context = CIContext()
+    private var continuation: CheckedContinuation<CGImage?, Never>?
+
+    var image: CGImage? {
+        get async {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func stream(_ stream: SCStream,
+                didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+                of type: SCStreamOutputType) {
+        guard continuation != nil,
+              let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let ciImage = CIImage(cvImageBuffer: buffer)
+        if let cgImage = context.createCGImage(ciImage, from: ciImage.extent) {
+            continuation?.resume(returning: cgImage)
+            continuation = nil
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Capture main display with ScreenCaptureKit and extract metadata and text
- Hide overlay while capturing to avoid capturing itself

## Testing
- `xcodebuild -scheme AIOverlay test` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68c14a2a74388328928103b26c0ac446